### PR TITLE
use more visible message

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -39,9 +39,21 @@ class PrivateModePlugin extends Plugin
              */
             $login = new Login();
             if (! $login->isLogged()) {
-                Alert::set($this->getValue('message'));
                 Redirect::url(DOMAIN_ADMIN);
             }
         }
+    }
+
+    public function loginBodyBegin()
+    {
+        $html  = '<div class="container">';
+        $html .= '<div class="row justify-content-md-center pt-5">';
+        $html .= '<div class="col-md-4 text-center alert alert-warning">';
+        $html .= $this->getValue('message');
+        $html .= '</div>';
+        $html .= '</div>';
+        $html .= '</div>';
+
+        return $html;
     }
 }


### PR DESCRIPTION
I did not see the message in testing, and think that in the `loginBodyBegin` hook would be a better place for it.